### PR TITLE
AttributeError: 'NoneType' object has no attribute 'get'

### DIFF
--- a/amazon-s3-backup/Dockerfile
+++ b/amazon-s3-backup/Dockerfile
@@ -8,9 +8,10 @@ COPY rootfs /
 # Setup base
 RUN apk add --no-cache \
     python3 \
-    py3-boto3@edge \
     py3-watchdog \
     py3-requests
+
+RUN pip3 install boto3
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
Hello, this PR fixes issues #7 
Reason: Small backups(a couple of megabytes) didn't got such error, but backups which I have (partial backup 130mb, full backup 1gb) got error. Supervisor didn't return 200 response on `f"/snapshots/{slug}/info"` some time after file is created(for 130mb it takes some seconds on my installation, for 1GB 2-4 minutes).
Solution: added retry strategy, I think it is impovement for stability, when supervisor api doesn't work because of some reason

Log of supervisor after fix, we see that file is created at 12:31:14 but snapshot creation completed at 12:35:13, extension got snapshot sucessfully at 12:35:35(6 attempt)
```
2021-07-20T12:31:14.837277000Z 21-07-20 15:31:14 INFO (MainThread) [supervisor.api.middleware.security] /snapshots/1c14c889/info access from 34443ade_amazon-s3-backup
2021-07-20T12:31:14.846326000Z 21-07-20 15:31:14 INFO (MainThread) [supervisor.api.middleware.security] /snapshots/1c14c889/info access from 34443ade_amazon-s3-backup
2021-07-20T12:31:34.872125000Z 21-07-20 15:31:34 INFO (MainThread) [supervisor.api.middleware.security] /snapshots/1c14c889/info access from 34443ade_amazon-s3-backup
2021-07-20T12:32:14.896429000Z 21-07-20 15:32:14 INFO (MainThread) [supervisor.api.middleware.security] /snapshots/1c14c889/info access from 34443ade_amazon-s3-backup
2021-07-20T12:33:34.985843000Z 21-07-20 15:33:34 INFO (MainThread) [supervisor.api.middleware.security] /snapshots/1c14c889/info access from 34443ade_amazon-s3-backup
2021-07-20T12:35:13.665235000Z 21-07-20 15:35:13 INFO (MainThread) [supervisor.snapshots] Creating full-snapshot with slug 1c14c889 completed
2021-07-20T12:35:35.092503000Z 21-07-20 15:35:35 INFO (MainThread) [supervisor.api.middleware.security] /snapshots/1c14c889/info access from 34443ade_amazon-s3-backup
```
Also this pr contains small fix of (#5) Looks like some alpine repo updated and now we got incorrect installation of boto3, I've installed it from pip